### PR TITLE
Feat/ai summary generation

### DIFF
--- a/ISSUE_install_failure_python39.md
+++ b/ISSUE_install_failure_python39.md
@@ -1,0 +1,94 @@
+# Issue: `pip install plainbook` fails on Python 3.9 due to invalid f-string expression
+
+## Summary
+Installing `plainbook` from PyPI (`0.1.7`) fails during package installation on Python 3.9.
+
+The failure is caused by invalid f-string expressions in `plainbook/ai_common.py` that include a backslash inside the expression part (for example `{'\n    '.join(parts)}`), which is not allowed in Python 3.9.
+
+---
+
+## Impact
+- `pip install plainbook` does not complete successfully for affected users.
+- Package cannot be used after install attempt.
+- Error output is noisy because a secondary `pip` traceback appears after the initial syntax error.
+
+---
+
+## Environment / Specs
+- OS: macOS
+- Shell: `zsh`
+- Python: 3.9 (Xcode-provided Python path seen in traceback)
+  - `/Applications/Xcode.app/Contents/Developer/.../Python3.framework/Versions/3.9/...`
+- Installer: `pip3`
+- Package version: `plainbook==0.1.7`
+
+---
+
+## Steps to Reproduce
+1. Open terminal on macOS with Python 3.9.
+2. Run:
+   - `pip3 install plainbook`
+3. Observe install output and traceback.
+
+---
+
+## Expected Behavior
+`plainbook` installs successfully with no syntax errors.
+
+## Actual Behavior
+Install fails with:
+
+```text
+SyntaxError: f-string expression part cannot include a backslash
+File ".../site-packages/plainbook/ai_common.py", line 125
+print(f"  Preceding context:\n    {'\n    '.join(parts)}")
+```
+
+Then `pip` emits a secondary error while formatting compile output:
+
+```text
+TypeError: encode() argument 'encoding' must be str, not None
+```
+
+---
+
+## Root Cause
+In `plainbook/ai_common.py`, the code uses backslash escapes inside f-string expression blocks:
+
+- `print(f"  Preceding context:\n    {'\n    '.join(parts)}")`
+- `print(f"  Cell information:\n    {'\n    '.join(parts)}")`
+
+Python 3.9 rejects this syntax (`f-string expression part cannot include a backslash`).
+
+---
+
+## Proposed Fix
+Refactor to compute the joined string before the f-string:
+
+```python
+joined = "\n    ".join(parts)
+print(f"  Preceding context:\n    {joined}")
+```
+
+And similarly for the `Cell information` print.
+
+This avoids backslashes in the f-string expression while preserving output format.
+
+---
+
+## Validation Plan
+After patching:
+1. Build and publish a new patch release (for example `0.1.8`).
+2. Verify install on Python 3.9:
+   - `pip3 install plainbook==0.1.8`
+3. Optional: run import smoke test:
+   - `python3 -c "import plainbook; print('ok')"`
+4. Confirm no syntax errors and no compile-time failures.
+
+---
+
+## Acceptance Criteria
+- [ ] Installation succeeds on Python 3.9.
+- [ ] No `SyntaxError` in `ai_common.py` during install.
+- [ ] Logging output remains unchanged in content/format.
+- [ ] Patch release published with fix.

--- a/SUMMARY_OF_CHANGES.md
+++ b/SUMMARY_OF_CHANGES.md
@@ -1,0 +1,13 @@
+## feat: add AI-generated notebook summary button and first-cell insertion
+
+- Add `Summary` action to the navbar and wire the UI event flow.
+- Implement the frontend handler to call the summary API, refresh the notebook, and focus the first cell.
+- Add the `/generate_notebook_summary` backend endpoint with existing AI config and billing error handling.
+- Add notebook-level `generate_notebook_summary()` logic to:
+    - generate a markdown summary from notebook context
+    - insert a new first markdown cell when missing
+    - update an existing auto-generated summary when present
+    - tag the summary cell with `metadata.plainbook_summary = true`
+- Add provider support for notebook summaries in Gemini and Claude integrations.
+- Add shared summary system instructions and a markdown-fence stripping helper.
+- Register the new `summarize_notebook` provider hook in the AI provider registry.

--- a/notebook.nlb
+++ b/notebook.nlb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fb3c472",
+   "metadata": {
+    "code_timestamp": "2026-03-11T12:47:10.356528",
+    "explanation": "",
+    "explanation_timestamp": "2026-03-11T13:22:31.090541",
+    "validation": {
+     "is_hidden": true,
+     "is_valid": true,
+     "message": "The code prints \"hi\" exactly 20 times, fulfilling the instruction."
+    },
+    "variables": {}
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "ai_instructions": "",
+  "input_files": [],
+  "is_locked": false,
+  "last_valid_code_cell": -1,
+  "last_valid_output": -1,
+  "last_valid_test_cell": -1,
+  "missing_input_files": [],
+  "share_output_with_ai": true
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plainbook/ai_common.py
+++ b/plainbook/ai_common.py
@@ -45,6 +45,17 @@ Return ONLY the code, no markdown formatting or explanations.
 Use assert statements for testing.
 """
 
+NOTEBOOK_SUMMARY_INSTRUCTIONS = """
+You are an assistant that writes a concise markdown summary for a Jupyter notebook.
+You are given the notebook cells in JSON format, along with outputs (if any) and
+available variable descriptions.
+Write a short first comment cell in markdown that summarizes:
+- the notebook goal
+- the main steps or sections
+- the key outputs or findings when they are visible
+Return ONLY markdown. Do not wrap the result in code fences.
+"""
+
 NAME_GENERATION_INSTRUCTIONS = """You need to summarize what a notebook cell does using two or three words.
 You will be given the cell's explanation, which describes what the cell does.
 Please return at least 2 words, and at most 3. Return only these words."""
@@ -224,6 +235,20 @@ def strip_markdown_code_fences(code):
     if code.endswith("```"):
         code = code[:-3].strip()
     return code
+
+
+def strip_markdown_fences(text):
+    """Strip markdown fences from generated markdown text."""
+    text = text.strip()
+    if text.startswith("```markdown"):
+        text = text[len("```markdown"):].strip()
+    elif text.startswith("```md"):
+        text = text[len("```md"):].strip()
+    elif text.startswith("```"):
+        text = text[3:].strip()
+    if text.endswith("```"):
+        text = text[:-3].strip()
+    return text
 
 
 def parse_validation_response(text):

--- a/plainbook/claude.py
+++ b/plainbook/claude.py
@@ -3,6 +3,7 @@ import anthropic
 from .ai_common import (
     SYSTEM_INSTRUCTIONS,
     TEST_SYSTEM_INSTRUCTIONS,
+    NOTEBOOK_SUMMARY_INSTRUCTIONS,
     CHECKING_INSTRUCTIONS,
     NAME_GENERATION_INSTRUCTIONS,
     build_context_prompt,
@@ -10,6 +11,7 @@ from .ai_common import (
     dump_ai_request,
     log_ai_request_size,
     parse_validation_response,
+    strip_markdown_fences,
     strip_markdown_code_fences,
 )
 
@@ -141,6 +143,46 @@ Code:
         print("Response:", response_text)
     code = strip_markdown_code_fences(response_text)
     return code
+
+
+def claude_generate_notebook_summary(
+    api_key,
+    preceding_code=None,
+    file_context=None,
+    model=None,
+    debug=False,
+    dump_ai_requests=False):
+    client = anthropic.Anthropic(api_key=api_key)
+    model = model or CLAUDE_MODEL
+
+    prompt = build_context_prompt(
+        preceding=preceding_code,
+        file_context=file_context)
+    prompt += """
+INSTRUCTIONS for Notebook Summary:
+Write a concise markdown summary for the notebook to be inserted as the first comment cell.
+Prefer a short title and 2-4 bullet points covering the notebook goal, main steps,
+and key findings when visible.
+
+Markdown:
+"""
+
+    if debug:
+        log_ai_request_size("claude generate_notebook_summary", NOTEBOOK_SUMMARY_INSTRUCTIONS, prompt,
+                            preceding=preceding_code, file_context=file_context)
+    if dump_ai_requests:
+        dump_ai_request("claude generate_notebook_summary", NOTEBOOK_SUMMARY_INSTRUCTIONS, prompt)
+
+    message = client.messages.create(
+        model=model,
+        max_tokens=1024,
+        system=NOTEBOOK_SUMMARY_INSTRUCTIONS,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    response_text = message.content[0].text
+    if debug:
+        print("Response:", response_text)
+    return strip_markdown_fences(response_text)
 
 
 def claude_validate_code(api_key, previous_code, code_to_validate, instructions, variable_context=None, model=None, debug=False, dump_ai_requests=False):

--- a/plainbook/gemini.py
+++ b/plainbook/gemini.py
@@ -4,6 +4,7 @@ from google.genai import types
 from .ai_common import (
     SYSTEM_INSTRUCTIONS,
     TEST_SYSTEM_INSTRUCTIONS,
+    NOTEBOOK_SUMMARY_INSTRUCTIONS,
     CHECKING_INSTRUCTIONS,
     NAME_GENERATION_INSTRUCTIONS,
     build_context_prompt,
@@ -11,6 +12,7 @@ from .ai_common import (
     dump_ai_request,
     log_ai_request_size,
     parse_validation_response,
+    strip_markdown_fences,
     strip_markdown_code_fences,
 )
 
@@ -143,6 +145,46 @@ Code:
         print("Response:", response.text)
     code = strip_markdown_code_fences(response.text)
     return code
+
+
+def gemini_generate_notebook_summary(
+    api_key,
+    preceding_code=None,
+    file_context=None,
+    model=None,
+    debug=False,
+    dump_ai_requests=False):
+    client = genai.Client(api_key=api_key)
+    model = model or GEMINI_GENERATE_MODEL
+
+    prompt = build_context_prompt(
+        preceding=preceding_code,
+        file_context=file_context)
+    prompt += """
+INSTRUCTIONS for Notebook Summary:
+Write a concise markdown summary for the notebook to be inserted as the first comment cell.
+Prefer a short title and 2-4 bullet points covering the notebook goal, main steps,
+and key findings when visible.
+
+Markdown:
+"""
+
+    if debug:
+        log_ai_request_size("gemini generate_notebook_summary", NOTEBOOK_SUMMARY_INSTRUCTIONS, prompt,
+                            preceding=preceding_code, file_context=file_context)
+    if dump_ai_requests:
+        dump_ai_request("gemini generate_notebook_summary", NOTEBOOK_SUMMARY_INSTRUCTIONS, prompt)
+
+    response = client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            system_instruction=NOTEBOOK_SUMMARY_INSTRUCTIONS
+        )
+    )
+    if debug:
+        print("Response:", response.text)
+    return strip_markdown_fences(response.text)
 
 
 def gemini_validate_code(api_key, previous_code, code_to_validate, instructions, variable_context=None, model=None, debug=False, dump_ai_requests=False):

--- a/plainbook/js/AppNavbar.js
+++ b/plainbook/js/AppNavbar.js
@@ -4,7 +4,7 @@ export default {
     emits: [
         'lock', 'refresh', 'interrupt', 'regenerate-all',
         'restart', 'reset-run-all', 'run-all', 'run-all-tests', 'clear-outputs', 'open-info', 'open-settings', 'debug-request',
-        'set-ai-provider', 'toggle-share-output'
+        'set-ai-provider', 'toggle-share-output', 'generate-summary'
         ],
     data() {
         return { aiDropdownOpen: false };
@@ -149,6 +149,16 @@ export default {
                             class="button is-warning">
                             <span class="icon"><i class="bx bx-seal-check"></i></span>
                             <span>Run tests</span>
+                        </button>
+
+                        <button v-if="hasNotebook"
+                            :disabled="cellCount === 0 || running"
+                            @mousedown.prevent
+                            @click="$emit('generate-summary')"
+                            title="Generate notebook summary"
+                            class="button is-link">
+                            <span class="icon"><i class="bx bx-notepad"></i></span>
+                            <span>Summary</span>
                         </button>
 
         </div>

--- a/plainbook/js/nb.js
+++ b/plainbook/js/nb.js
@@ -205,6 +205,28 @@ createApp({
             }
         };
 
+        const ui_generateNotebookSummary = async () => {
+            if (!activeAiProvider.value) {
+                throw new Error('No AI provider is active. Please set an API key in Settings.');
+            }
+            flushActiveEdits();
+            await waitForPendingSaves();
+            asRead.value = false;
+            try {
+                running.value = true;
+                runningActivity.value = { type: 'generating', cellIndex: 0, cellName: 'Notebook summary' };
+                const r = await apiCall('/generate_notebook_summary', 'POST');
+                if (r.status !== 'success') throw new Error(r.message || 'Summary generation failed');
+                await reloadNotebook();
+                activeIndex.value = 0;
+            } catch (err) {
+                throw new Error('Failed to generate notebook summary', { cause: err });
+            } finally {
+                running.value = false;
+                runningActivity.value = { type: null, cellIndex: null };
+            }
+        };
+
         const sendExplanationToServer = async (content, cellIndex) => {
             asRead.value = false;
             const savePromise = (async () => {
@@ -867,7 +889,8 @@ createApp({
             explanationEditKey, deleteCell, moveCell,
             clearOutputs, activeAiProvider, availableAiProviders, setActiveAiProvider, isCodespace, hasGeminiKey, hasClaudeKey,
             restarting, ui_restart,
-            ui_runTestCell, ui_runAllTests, ui_saveExplanationAndRunTest, ui_forceRegenerateTestCode };
+            ui_runTestCell, ui_runAllTests, ui_saveExplanationAndRunTest, ui_forceRegenerateTestCode,
+            ui_generateNotebookSummary };
     },
 
 template: `#app-template`,

--- a/plainbook/main.py
+++ b/plainbook/main.py
@@ -512,6 +512,24 @@ def generate_test_code():
         return dict(status='cancelled', code=None)
 
 
+@post('/generate_notebook_summary')
+@stateful
+@require_token
+def generate_notebook_summary():
+    api_key, ai_provider, model, error = _get_ai_config()
+    if error:
+        return dict(status='error', message=error)
+    try:
+        cell, index = notebook.generate_notebook_summary(
+            api_key, ai_provider=ai_provider, model=model)
+    except Exception as e:
+        friendly = _check_billing_error(e)
+        if friendly:
+            return dict(status='error', message=friendly)
+        raise
+    return dict(status='success', cell=cell, index=index)
+
+
 @post('/execute_test_cell')
 @stateful
 @require_token

--- a/plainbook/plainbook.py
+++ b/plainbook/plainbook.py
@@ -15,12 +15,12 @@ import uuid
 import nbformat
 import requests
 
-from .gemini import gemini_generate_code, gemini_validate_code, gemini_generate_cell_name, gemini_generate_test_code
-from .claude import claude_generate_code, claude_validate_code, claude_generate_cell_name, claude_generate_test_code
+from .gemini import gemini_generate_code, gemini_validate_code, gemini_generate_cell_name, gemini_generate_test_code, gemini_generate_notebook_summary
+from .claude import claude_generate_code, claude_validate_code, claude_generate_cell_name, claude_generate_test_code, claude_generate_notebook_summary
 
 AI_PROVIDERS = {
-    "gemini": {"generate": gemini_generate_code, "validate": gemini_validate_code, "name": gemini_generate_cell_name, "generate_test": gemini_generate_test_code},
-    "claude": {"generate": claude_generate_code, "validate": claude_validate_code, "name": claude_generate_cell_name, "generate_test": claude_generate_test_code},
+    "gemini": {"generate": gemini_generate_code, "validate": gemini_validate_code, "name": gemini_generate_cell_name, "generate_test": gemini_generate_test_code, "summarize_notebook": gemini_generate_notebook_summary},
+    "claude": {"generate": claude_generate_code, "validate": claude_validate_code, "name": claude_generate_cell_name, "generate_test": claude_generate_test_code, "summarize_notebook": claude_generate_notebook_summary},
 }
 
 MAX_OUTPUT_CHARS_FOR_AI = 2000
@@ -945,6 +945,58 @@ class Plainbook:
                     return new_code, True
                 else:
                     return None, False
+            finally:
+                self.ai_request_pending = False
+
+    def generate_notebook_summary(self, api_key, ai_provider="gemini", model=None):
+        """Generate or refresh the notebook summary markdown cell at index 0."""
+        with self._lock:
+            summary_exists = (
+                len(self.nb.cells) > 0 and
+                self.nb.cells[0].cell_type == 'markdown' and
+                self.nb.cells[0].metadata.get('plainbook_summary')
+            )
+            cells = [
+                self._get_cell_json_for_ai(i)
+                for i in range(len(self.nb.cells))
+                if self.nb.cells[i].cell_type != 'test' and not (summary_exists and i == 0)
+            ]
+            context_nb = nbformat.v4.new_notebook()
+            context_nb.cells = cells
+            preceding_code = nbformat.writes(context_nb, indent=4)
+            files_context = self._get_files_context()
+            if self.ai_request_pending:
+                raise RuntimeError("An AI request is already pending.")
+            try:
+                self.ai_request_pending = True
+                summarize_fn = AI_PROVIDERS[ai_provider]["summarize_notebook"]
+                summary_md = summarize_fn(
+                    api_key,
+                    preceding_code=preceding_code,
+                    file_context=files_context,
+                    model=model,
+                    debug=self.debug,
+                    dump_ai_requests=self.dump_ai_requests)
+                summary_md = tostring(summary_md).strip()
+                if not summary_md:
+                    raise RuntimeError("AI summary generation returned empty content.")
+                if summary_exists:
+                    cell = self.nb.cells[0]
+                    cell.source = summary_md
+                else:
+                    cell = nbformat.v4.new_markdown_cell(source=summary_md)
+                    self.nb.cells.insert(0, cell)
+                    if self.last_executed_cell >= 0:
+                        self.last_executed_cell += 1
+                    if self.last_valid_code_cell >= 0:
+                        self.last_valid_code_cell += 1
+                    if self.last_valid_output_cell >= 0:
+                        self.last_valid_output_cell += 1
+                    if self.last_valid_test_cell >= 0:
+                        self.last_valid_test_cell += 1
+                cell.metadata['plainbook_summary'] = True
+                self._write()
+                return cell, 0
             finally:
                 self.ai_request_pending = False
 

--- a/plainbook/views/index.html
+++ b/plainbook/views/index.html
@@ -62,6 +62,7 @@
         @debug-request="sendDebugRequest"
         @set-ai-provider="setActiveAiProvider"
         @run-all-tests="ui_runAllTests"
+        @generate-summary="ui_generateNotebookSummary"
     />    
 
     <panel-bar


### PR DESCRIPTION
## feat: add AI-generated notebook summary button and first-cell insertion

- Add `Summary` action to the navbar and wire the UI event flow.
- Implement the frontend handler to call the summary API, refresh the notebook, and focus the first cell.
- Add the `/generate_notebook_summary` backend endpoint with existing AI config and billing error handling.
- Add notebook-level `generate_notebook_summary()` logic to:
    - generate a markdown summary from notebook context
    - insert a new first markdown cell when missing
    - update an existing auto-generated summary when present
    - tag the summary cell with `metadata.plainbook_summary = true`
- Add provider support for notebook summaries in Gemini and Claude integrations.
- Add shared summary system instructions and a markdown-fence stripping helper.
- Register the new `summarize_notebook` provider hook in the AI provider registry.

Reference: Issue #21 